### PR TITLE
Namen vereinheitlicht und Tippfehler korrigiert

### DIFF
--- a/src/main/java/ch/mab/plansch/demo/controller/DegreeController.java
+++ b/src/main/java/ch/mab/plansch/demo/controller/DegreeController.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 import java.util.List;
 
 @RestController
-@RequestMapping("/degree")
+@RequestMapping("/degrees")
 public class DegreeController {
 
     @GetMapping

--- a/src/main/java/ch/mab/plansch/demo/controller/ProfileController.java
+++ b/src/main/java/ch/mab/plansch/demo/controller/ProfileController.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/profiles")
-public class ProfilesController {
+public class ProfileController {
 
     @GetMapping()
     public List<Profile> retrieveAllProfiles() {

--- a/src/main/java/ch/mab/plansch/demo/controller/ProfilesController.java
+++ b/src/main/java/ch/mab/plansch/demo/controller/ProfilesController.java
@@ -1,6 +1,6 @@
 package ch.mab.plansch.demo.controller;
 
-import ch.mab.plansch.demo.model.Profiles;
+import ch.mab.plansch.demo.model.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,14 +15,14 @@ import java.util.UUID;
 public class ProfilesController {
 
     @GetMapping()
-    public List<Profiles> retrieveAllProfiles() {
+    public List<Profile> retrieveAllProfiles() {
         return Collections.emptyList();
     }
 
     @GetMapping("/{id}")
-    public Profiles retrieveProfiles(
+    public Profile retrieveProfiles(
             @PathVariable("id") UUID id
     ) {
-        return new Profiles();
+        return new Profile();
     }
 }

--- a/src/main/java/ch/mab/plansch/demo/model/Degree.java
+++ b/src/main/java/ch/mab/plansch/demo/model/Degree.java
@@ -14,5 +14,5 @@ public class Degree {
     String id;
     String name;
     Set<String> groups;
-    Set<String> prodiles; // aufgrund eines Kommentars von Herrn Gruntz sollten die Gruppen und Profilierungen vom Studiengang her referenziert werden (GSW usw. können ja in mehreren Studiengängen angeboten werden
+    Set<String> profiles; // aufgrund eines Kommentars von Herrn Gruntz sollten die Gruppen und Profilierungen vom Studiengang her referenziert werden (GSW usw. können ja in mehreren Studiengängen angeboten werden
 }

--- a/src/main/java/ch/mab/plansch/demo/model/ModuleGroup.java
+++ b/src/main/java/ch/mab/plansch/demo/model/ModuleGroup.java
@@ -9,5 +9,5 @@ public class ModuleGroup {
     String name;
     UUID parent; // für die Abbildung Verschachtelung
     Set<UUID> modules;
-    int minima;
+    int minNoOfModules;
 }

--- a/src/main/java/ch/mab/plansch/demo/model/Profile.java
+++ b/src/main/java/ch/mab/plansch/demo/model/Profile.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 // das gleiche.
 // => ies aufgrund der Diskussion am Montag, Herr Gruntz wird dies ebenfalls so in der GraphQL API abbilden
 // über den Namen kann man noch streiten, würde ich aber dann so übernehmen, wie es in der GraphQL API ist (siehe auch Kommentar auf Github)
-public class Profiles {
+public class Profile {
     UUID id;
     String name;
     Set<UUID> modules;


### PR DESCRIPTION
- Gleiche Bezeichnung für Mindestanzahl in ModuleGroup und Profile, Tippfehler korrigert

- Controller-Namen alle Singluar

- REST Endpoints alle Plural

- Model-Namen alle Singular